### PR TITLE
feat: Add instructions option to CLI and enhance XML generation

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,6 +12,10 @@ pub struct Cli {
     #[arg(short, long, value_name = "DIR")]
     pub directory: PathBuf,
 
+    /// Instructions for the prompt
+    #[arg(short = 'n', long, value_name = "INSTRUCTIONS")]
+    pub instructions: Option<String>,
+
     /// Generate XML output
     #[arg(short, long)]
     pub xml: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Generate XML if requested
     if cli.xml {
-        let xml = XmlGenerator::generate(&results);
+        let xml = XmlGenerator::generate(&results, cli.instructions.as_deref().unwrap_or(""));
         if let Some(output_path) = cli.output {
             std::fs::write(&output_path, xml)?;
             println!("XML output written to: {}", output_path.display());

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -12,9 +12,14 @@ struct FileNode {
 pub struct XmlGenerator;
 
 impl XmlGenerator {
-    pub fn generate(files: &[FileInfo]) -> String {
+    pub fn generate(files: &[FileInfo], instructions: &str) -> String {
         let root = Self::build_tree(files);
         let mut xml = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<files>\n");
+
+        // Add user instructions
+        xml.push_str("  <instructions>\n    <![CDATA[\n");
+        xml.push_str(instructions);
+        xml.push_str("\n    ]]>\n  </instructions>\n\n");
 
         // Generate and add the tree visualization
         let tree_view = Self::generate_tree_view(&root);


### PR DESCRIPTION
- Introduced a new `instructions` field in the CLI for user-defined prompts.
- Updated the XML generation logic to include user instructions in the output, improving the context and usability of the generated XML.
- This change enhances user experience by allowing custom instructions to be embedded within the XML structure.
