### PR TITLE
feat: Add semantic release workflow for automated versioning

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,0 +1,37 @@
+name: Semantic Release
+
+on:
+  # 1) Trigger after the "Code Quality & Tests" workflow completes
+  workflow_run:
+    workflows: ["Code Quality & Tests"]
+    types: [completed]
+
+jobs:
+  semantic_release:
+    # 2) Only run if the previous workflow concluded successfully
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          # If you need specific components:
+          components: clippy, rustfmt
+
+      - name: Install cargo-release
+        run: cargo install cargo-release
+
+      # 3) Run the cargo-release command to bump the version
+      - name: Run cargo-release
+        run: cargo release patch --no-publish
+        env:
+          # The GITHUB_TOKEN is automatically provided by GitHub Actions.
+          # cargo-release uses this to create release tags and GitHub Releases.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+          # Only needed if you also publish to crates.io
+          # CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
- Introduced a new GitHub Actions workflow for semantic release, triggered after the "Code Quality & Tests" workflow completes.
- The workflow checks out the repository, sets up the Rust environment, installs the `cargo-release` tool, and runs the `cargo release patch` command to automatically bump the version.
- This addition streamlines the release process, ensuring that versioning is handled consistently and efficiently.
